### PR TITLE
Add surrounding spaces in calc()

### DIFF
--- a/_docs/mixins/calc.md
+++ b/_docs/mixins/calc.md
@@ -13,23 +13,23 @@ Add vendor-prefix for the css3 `calc()` function.
 
 ```stylus
 body
-    width calc( "100%-80px" )
+    width calc( "100% - 80px" )
 
 body
-    width calc( "100%-80px", 90% )
+    width calc( "100% - 80px", 90% )
 ```
 
 ### Result
 
 ```css
 body {
-  width: -webkit-calc(100%-80px);
-  width: calc(100%-80px);
+  width: -webkit-calc(100% - 80px);
+  width: calc(100% - 80px);
 }
 
 body {
   width: 90%;
-  width: -webkit-calc(100%-80px);
-  width: calc(100%-80px);
+  width: -webkit-calc(100% - 80px);
+  width: calc(100% - 80px);
 }
 ```

--- a/test/cases/mixins-calc.css
+++ b/test/cases/mixins-calc.css
@@ -1,9 +1,9 @@
 body {
-  width: -webkit-calc(100%-80px);
-  width: calc(100%-80px);
+  width: -webkit-calc(100% - 80px);
+  width: calc(100% - 80px);
 }
 body {
   width: 90%;
-  width: -webkit-calc(100%-80px);
-  width: calc(100%-80px);
+  width: -webkit-calc(100% - 80px);
+  width: calc(100% - 80px);
 }

--- a/test/cases/mixins-calc.styl
+++ b/test/cases/mixins-calc.styl
@@ -1,7 +1,7 @@
 @import 'kouto-swiss'
 
 body
-    width calc( "100%-80px" )
+    width calc( "100% - 80px" )
 
 body
-    width calc( "100%-80px", 90% )
+    width calc( "100% - 80px", 90% )


### PR DESCRIPTION
Required, as specified here: https://developer.mozilla.org/en-US/docs/Web/CSS/calc
