### PR TITLE
consider adding a default font path variable

### DIFF
--- a/_docs/mixins/font-face.md
+++ b/_docs/mixins/font-face.md
@@ -13,6 +13,8 @@ Simple `@font-face` mixin.
 * `formats`: the formats to includes. *Optional*. Default: `eot woff2 woff truetype svg` Accepted words: `eot woff2 woff truetype ttf opentype otf svg`
 * `svg-font-name`: the svg font name. *Optional*. Default: use the `name` parameters.
 
+**Note:** you can add a default path through: `ks-font-src = './src/public/fonts/'`
+
 ### Usage
 
 ```stylus
@@ -21,6 +23,9 @@ font-face( "Roboto", "./fonts/Roboto-Regular-webfont", normal )
 font-face( "Roboto", "./fonts/Roboto-Italic-webfont", normal, italic )
 
 font-face( "OpenSans", "./fonts/OpenSans", formats: woff )
+
+ks-font-src = './src/fonts/'
+font-face( "Roboto", "Roboto-Regular-webfont", normal )
 ```
 
 ### Result
@@ -44,5 +49,12 @@ font-face( "OpenSans", "./fonts/OpenSans", formats: woff )
 @font-face {
   font-family: "OpenSans";
   src: url("./fonts/OpenSans.woff") format("woff");
+}
+
+@font-face {
+  font-family: "Roboto";
+  font-weight: normal;
+  src: url("./src/fonts/Roboto-Regular-webfont.eot");
+  src: url("./src/fonts/Roboto-Regular-webfont.eot?#iefix") format("embedded-opentype"), url("./src/fonts/Roboto-Regular-webfont.woff2") format("woff2"), url("./src/fonts/Roboto-Regular-webfont.woff") format("woff"), url("./src/fonts/Roboto-Regular-webfont.ttf") format("truetype"), url("./src/fonts/Roboto-Regular-webfont.svg#Roboto") format("svg");
 }
 ```

--- a/lib/kouto-swiss/mixins/font-face.styl
+++ b/lib/kouto-swiss/mixins/font-face.styl
@@ -1,6 +1,8 @@
 ks-font-face( name, font-src, weight = false, style = false, formats = eot woff2 woff truetype svg, svg-font-name = false )
     @font-face
         font-family name
+        if ks-font-src is defined
+            font-src = ks-font-src + font-src
         if weight
             font-weight weight
         if style

--- a/lib/kouto-swiss/vars/index.styl
+++ b/lib/kouto-swiss/vars/index.styl
@@ -2,6 +2,9 @@
 
 ks-no-conflict ?= false
 
+// Default path for fonts
+//ks-font-src = './fonts/'
+
 // Default browsers version's for support
 ks-support-ie = ks-support-ie-default = 8
 ks-support-firefox = ks-support-firefox-default = 25

--- a/test/cases/mixins-font-face.css
+++ b/test/cases/mixins-font-face.css
@@ -52,3 +52,9 @@
   src: url("./fonts/Entypo-webfont.eot");
   src: url("./fonts/Entypo-webfont.eot?#iefix") format("embedded-opentype"), url("./fonts/Entypo-webfont.ttf") format("truetype"), url("./fonts/Entypo-webfont.svg#entypo") format("svg");
 }
+@font-face {
+  font-family: "Roboto";
+  font-weight: normal;
+  src: url("./myfolder/fonts/Roboto-Regular-webfont.eot");
+  src: url("./myfolder/fonts/Roboto-Regular-webfont.eot?#iefix") format("embedded-opentype"), url("./myfolder/fonts/Roboto-Regular-webfont.woff2") format("woff2"), url("./myfolder/fonts/Roboto-Regular-webfont.woff") format("woff"), url("./myfolder/fonts/Roboto-Regular-webfont.ttf") format("truetype"), url("./myfolder/fonts/Roboto-Regular-webfont.svg#Roboto") format("svg");
+}

--- a/test/cases/mixins-font-face.styl
+++ b/test/cases/mixins-font-face.styl
@@ -16,3 +16,6 @@ font-face( "OpenSans", "./fonts/OpenSans", formats: woff )
 font-face( "EntypoIcons", "./fonts/Entypo-webfont", formats: eot truetype svg, svg-font-name: "entypo" )
 
 font-face( "EntypoIcons", "./fonts/Entypo-webfont", formats: eot ttf svg, svg-font-name: "entypo" )
+
+ks-font-src = './myfolder/fonts/'
+font-face( "Roboto", "Roboto-Regular-webfont", normal )


### PR DESCRIPTION
Hi,
I usually save my fonts into a single folder("./src/fonts"), I think many people do also.
We could add a variable for font path, when is defined, the path is prefixed to the `font-scr` of `ks-font-face` mixin.

example:
```css
ks-font-src = './myfolder/fonts/'
font-face( "Roboto", "Roboto-Regular-webfont", normal )
```

```css
@font-face {
  font-family: "Roboto";
  font-weight: normal;
  src: url("./myfolder/fonts/Roboto-Regular-webfont.eot");
  src: url("./myfolder/fonts/Roboto-Regular-webfont.eot?#iefix") format("embedded-opentype"), url("./myfolder/fonts/Roboto-Regular-webfont.woff2") format("woff2"), url("./myfolder/fonts/Roboto-Regular-webfont.woff") format("woff"), url("./myfolder/fonts/Roboto-Regular-webfont.ttf") format("truetype"), url("./myfolder/fonts/Roboto-Regular-webfont.svg#Roboto") format("svg");
}
```