### PR TITLE
Update rem function (multiple values)

### DIFF
--- a/_docs/functions/rem.md
+++ b/_docs/functions/rem.md
@@ -1,25 +1,27 @@
 # rem()
 
-Converts `pixels` to `rem`.  
+Converts `pixels` to `rem`.
 Assumes `1rem = 16px`. You can override by passing a new value to the global variable `ks-rem-base`.
 
 ### Signature
 
-`rem( value )`
+`rem( values )`
 
-* `value`: value to convert.
+* `values`: value(s) to convert.
 
 ### Usage
 
 ```stylus
 div
     font-size rem( 12px )
+    margin rem( 10px auto 20 )
 
 ks-rem-base = 20px
 
 div
     font-size rem( 16 )
-        
+    margin rem( 10 auto 20px )
+
 ```
 
 ### Result
@@ -27,9 +29,11 @@ div
 ```css
 div {
   font-size: 0.75rem;
+  margin: 0.625rem auto 1.25rem;
 }
 
 div {
   font-size: 0.8rem;
+  margin: 0.5rem auto 1rem;
 }
 ```

--- a/lib/kouto-swiss/functions/rem.styl
+++ b/lib/kouto-swiss/functions/rem.styl
@@ -1,8 +1,13 @@
 ks-rem-base = 16px
 
-ks-rem( value )
-    value = _strip-units( value )
-    base = ks-rem-base is a "unit" ? _strip-units( ks-rem-base ) : 16
-    value / base * 1rem
+ks-rem( values )
+    base = ks-rem-base is a "unit" ? ks-rem-base : 16
+    result = null
+    for value in values
+      	if type( value ) == "unit" && ( unit( value ) == "px" || unit( value ) == "" )
+        		value = unit( round( value / base, 3 ), "rem" )
+        		if value == "0rem" { value = 0 }
+        result = result != null ? result value : value
+    result
 
 rem = ks-rem unless ks-no-conflict

--- a/test/cases/functions-rem.css
+++ b/test/cases/functions-rem.css
@@ -7,16 +7,28 @@ body {
   font-size: 1rem;
   font-size: 1.5rem;
   font-size: 0.625rem;
+  margin: 0.75rem 1rem;
+  margin: 0.75rem 1rem;
+  margin: 0.75rem 1em;
+  margin: 0 auto 0;
 }
 body {
   font-size: 0.6rem;
   font-size: 0.8rem;
   font-size: 1.2rem;
   font-size: 0.5rem;
+  margin: 0.6rem 0.8rem;
+  margin: 0.6rem 0.8rem;
+  margin: 0.6rem 1em;
+  margin: 0 auto 0;
 }
 body {
   font-size: 0.75rem;
   font-size: 1rem;
   font-size: 1.5rem;
   font-size: 0.625rem;
+  margin: 0.75rem 1rem;
+  margin: 0.75rem 1rem;
+  margin: 0.75rem 1em;
+  margin: 0 auto 0;
 }

--- a/test/cases/functions-rem.styl
+++ b/test/cases/functions-rem.styl
@@ -9,6 +9,10 @@ body
     font-size rem( 16px )
     font-size rem( 24px )
     font-size rem( 10px )
+    margin rem( 12 16 )
+    margin rem( 12px 16 )
+    margin rem( 12px 1em )
+    margin rem( 0 auto 0px )
 
 ks-rem-base = 20px
 
@@ -17,6 +21,10 @@ body
     font-size rem( 16 )
     font-size rem( 24 )
     font-size rem( 10 )
+    margin rem( 12 16 )
+    margin rem( 12px 16 )
+    margin rem( 12px 1em )
+    margin rem( 0 auto 0px )
 
 ks-rem-base = false
 
@@ -25,3 +33,7 @@ body
     font-size rem( 16 )
     font-size rem( 24 )
     font-size rem( 10 )
+    margin rem( 12 16 )
+    margin rem( 12px 16 )
+    margin rem( 12px 1em )
+    margin rem( 0 auto 0px )


### PR DESCRIPTION
The current function rem (http://git.io/veUzW) allows to convert only
one value. I updated the rem function, to be able to use multiple values.
For example `margin rem(10 auto 20)`. Docs and tests are also updated.