### PR TITLE
Refactor utility hide-text()

### DIFF
--- a/_docs/utilities/hide-text.md
+++ b/_docs/utilities/hide-text.md
@@ -4,7 +4,7 @@ The hide-text mixins will hide the text of the selector where it is declared. Us
 
 > This mixin is based on which from [bourbon.io](http://bourbon.io).
 
-A height declaration is required for this to function.
+A height declaration is no longer required, but inline-level elements will need block-level display styles ("block", "inline-block", etc) applied.
 
 ### Usage
 
@@ -12,7 +12,7 @@ A height declaration is required for this to function.
 h1
     height 75px
     background url( logo.png ) top left no-repeat
-    hide-text()    
+    hide-text()
 ```
 
 ### Result
@@ -22,11 +22,7 @@ h1 {
   height: 75px;
   background: url("logo.png") top left no-repeat;
   overflow: hidden;
-}
-h1:before {
-  content: "";
-  display: block;
-  width: 0;
-  height: 100%;
+  text-indent: 101%;
+  white-space: nowrap;
 }
 ```

--- a/lib/kouto-swiss/utilities/hide-text.styl
+++ b/lib/kouto-swiss/utilities/hide-text.styl
@@ -1,9 +1,6 @@
 ks-hide-text()
     overflow hidden
-    &:before
-        content ""
-        display block
-        width 0
-        height 100%
+    text-indent 101%
+    white-space nowrap
 
 hide-text = ks-hide-text unless ks-no-conflict

--- a/test/cases/utilities-hide-text.css
+++ b/test/cases/utilities-hide-text.css
@@ -2,10 +2,6 @@ h1 {
   height: 75px;
   background: url("logo.png") top left no-repeat;
   overflow: hidden;
-}
-h1:before {
-  content: "";
-  display: block;
-  width: 0;
-  height: 100%;
+  text-indent: 101%;
+  white-space: nowrap;
 }


### PR DESCRIPTION
The utility hide-text() has been refactored in the [Bourboun](git.io/uj1COQ).
A height declaration is no longer required.